### PR TITLE
[WIP] Hack that makes accuracy tests (including python level) start passing

### DIFF
--- a/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
@@ -297,7 +297,9 @@ void leaf_eval_classification(
   sparse_nodelist.clear();
 
   int non_leaf_counter = 0;
-  bool condition_global = (curr_depth == max_depth);
+  // XXX: This line fixes the inaccuracy in max_depth==1 tree leaf predictions
+  // I still don't fully understand its role, but it seems interesting
+  bool condition_global = true;  // XXX removed: (curr_depth == max_depth);
   if (max_leaves != -1)
     condition_global = condition_global || (tree_leaf_cnt >= max_leaves);
 

--- a/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
@@ -299,7 +299,8 @@ void leaf_eval_classification(
   int non_leaf_counter = 0;
   // XXX: This line fixes the inaccuracy in max_depth==1 tree leaf predictions
   // I still don't fully understand its role, but it seems interesting
-  bool condition_global = true;  // XXX removed: (curr_depth == max_depth);
+  bool condition_global =
+    curr_depth >= max_depth - 1;  // XXX removed: (curr_depth == max_depth);
   if (max_leaves != -1)
     condition_global = condition_global || (tree_leaf_cnt >= max_leaves);
 


### PR DESCRIPTION
I don't fully understand these codepaths, but based on a some debug hunting, it appears to that way too many nodes are getting flagged as LEAF in the flag list, which creates inconsistencies going into convert_scatter_to_gather. Basically, we populate samplelist with fewer than nodecount[i] valid entries, leaving the rest as zero. Then when we get to make_leaf_gather_classification_kernel, we find these `samplelist[i] == 0` entries and it acts like `labels[i]` is just repeated over and over in `shmemhist_parent`. If `labels[i]` happens to be the majority class (which happens most of the time), this still delivers the right prediction, but if `labels[i]` is the minority class, we end up with a nonsensical prediction in this node.

I'm sure this is not the right fix, but it's a demonstrated hack that may help lead to a better fix. With this hack, the previously-failing C++ accuracy test passes, as does the previous python demo test. Encouragingly, a python-level test with the airline dataset now matches sklearn accuracy results (when using a reasonable number of bins).